### PR TITLE
Update2 author.php

### DIFF
--- a/author.php
+++ b/author.php
@@ -245,6 +245,12 @@ $posts = get_posts($args);
                                         </li>
                                     <?php } ?>
 
+                                    <?php if(is_array($strutture) && count($strutture) > 0)  { ?>
+                                        <li>
+                                            <a class="list-item scroll-anchor-offset" href="#art-par-strutture" title="Vai al paragrafo <?php _e("Strutture", "design_scuole_italia"); ?>"><?php _e("Strutture", "design_scuole_italia"); ?></a>
+                                        </li>
+                                    <?php } ?>
+                                    
                                     <?php
                                     if(trim($altre_info) != ""){
                                         ?>


### PR DESCRIPTION
Aggiunta link "strutture" menù laterale sinistro nella pagina persone.

## Descrizione
Nella pagina persone è stato aggiunto il link nel menù a sinistra alle strutture della persona. Prima erano presenti gli altri collegamenti (documenti, articoli, progetti, contatti...) ma questo mancava

## Checklist

- [ x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [ x] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).